### PR TITLE
Refactor/separate views 0428 )(jvson/pat-31-refactoring-view-to-be-split-between-desktop-mobile)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const Homepage: NextPage<{
         <title>⌘</title>
       </Head>
       {/* Main view will go here */}
-      <MapView events={events_v0} />
+      <MapView events_v0={events_v0} />
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,32 +1,32 @@
 import Head from "next/head";
 import { NextPage } from "next";
-import type { User } from '@supabase/supabase-js'
-import type { GetServerSidePropsContext } from 'next'
-import { createClient } from '@/supabase/server-props'
+import type { GetServerSidePropsContext } from "next";
+import { createClient } from "@/supabase/server-props";
 import { type Database } from "@/models/supabase_types";
 import MapView from "@/views";
 
-
-const Homepage: NextPage<{ events_v0: Database['public']['Tables']['events_v0']['Row'][] }> = ({ events_v0 }) => {
+const Homepage: NextPage<{
+  events_v0: Database["public"]["Tables"]["events_v0"]["Row"][];
+}> = ({ events_v0 }) => {
   return (
     <div>
       <Head>
         <title>⌘</title>
       </Head>
-      { /* Main view will go here */}
+      {/* Main view will go here */}
       <MapView events={events_v0} />
     </div>
-  )
+  );
 };
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const supabase = createClient(context)
+  const supabase = createClient(context);
   const { data: events_v0 } = await supabase.from("events_v0").select();
   return {
     props: {
       events_v0: events_v0,
     },
-  }
+  };
 }
 
 export default Homepage;

--- a/src/views/index.tsx
+++ b/src/views/index.tsx
@@ -1,180 +1,182 @@
-import Map from "@/components/Map";
 // views/
+import Map from "@/components/Map";
 import { Button } from "@/components/reusable/Button";
 import mapboxClient from "@/services/MapboxClient";
-import createClient from '@/supabase/api';
 import {
-	Cross2Icon,
-	PlusCircledIcon,
-	SewingPinFilledIcon,
-	ThickArrowUpIcon,
+  Cross2Icon,
+  PlusCircledIcon,
+  SewingPinFilledIcon,
+  ThickArrowUpIcon,
 } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
 import { Database } from "@/models/supabase_types";
 
 interface MapViewProps {
-  events: Database['public']['Tables']['events_v0']['Row'][];
+  events: Database["public"]["Tables"]["events_v0"]["Row"][];
 }
 
 const MapView: React.FC<MapViewProps> = ({ events }) => {
-	// modes
-	const [waypointMode, setWaypointMode] = useState(false);
-	const [selectedWaypoint, setSelectedWaypoint] = useState<
-		[number, number] | null
-	>(null);
+  // modes
+  const [waypointMode, setWaypointMode] = useState(false);
+  const [selectedWaypoint, setSelectedWaypoint] = useState<
+    [number, number] | null
+  >(null);
 
-	useEffect(() => {
-     if (!events || events.length === 0) return;
+  useEffect(() => {
+    if (!events || events.length === 0) return;
 
-     for (const row of events) {
-       if (row && typeof row.longitude === 'number' && typeof row.latitude === 'number') {
-         mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
-       }
-     }
-   }, [events]);
+    for (const row of events) {
+      if (
+        row &&
+        typeof row.longitude === "number" &&
+        typeof row.latitude === "number"
+      ) {
+        mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
+      }
+    }
+  }, [events]);
 
-	useEffect(() => {
-		if (waypointMode) {
-			document.body.style.cursor = "crosshair";
-			const handleClick = (e: mapboxgl.MapMouseEvent) => {
-				const coordinates = e.lngLat.toArray() as [number, number];
-				setSelectedWaypoint(coordinates);
+  useEffect(() => {
+    if (waypointMode) {
+      document.body.style.cursor = "crosshair";
+      const handleClick = (e: mapboxgl.MapMouseEvent) => {
+        const coordinates = e.lngLat.toArray() as [number, number];
+        setSelectedWaypoint(coordinates);
 
-				mapboxClient.camera.zoomTo(coordinates, 18, true);
-				mapboxClient.events.addBaseMarker(coordinates);
-				setWaypointMode(false);
-			};
+        mapboxClient.camera.zoomTo(coordinates, 18, true);
+        mapboxClient.events.addBaseMarker(coordinates);
+        setWaypointMode(false);
+      };
 
-			mapboxClient.getMap().once("click", handleClick);
+      mapboxClient.getMap().once("click", handleClick);
 
-			return () => {
-				document.body.style.cursor = "";
-				mapboxClient.getMap().off("click", handleClick);
-			};
-		} else {
-			document.body.style.cursor = "";
-		}
-	}, [waypointMode]);
+      return () => {
+        document.body.style.cursor = "";
+        mapboxClient.getMap().off("click", handleClick);
+      };
+    } else {
+      document.body.style.cursor = "";
+    }
+  }, [waypointMode]);
 
+  const openInGoogleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+        "_blank",
+      );
+    }
+  };
 
-	const openInGoogleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(
-				`https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
-				"_blank",
-			);
-		}
-	};
+  const openInAppleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
+    }
+  };
 
-	const openInAppleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
-		}
-	};
+  const createEvent = () => {
+    // perform api call here, will just print to cosnole for now
+    // const supabase = createClient();
+    console.log("* Attempted to create event");
+  };
 
-	const createEvent = () => {
-	  // perform api call here, will just print to cosnole for now
-		// const supabase = createClient();
-    	console.log("* Attempted to create event");
-	}
+  return (
+    <div>
+      <div className="absolute inset-0">
+        <Map />
+      </div>
 
-	return (
-		<div>
-			<div className="absolute inset-0">
-				<Map />
-			</div>
+      <div className="overlay-wrapper inset-0 z-10">
+        <Button
+          icon={<SewingPinFilledIcon className="w-5 h-5" />}
+          position={"bottom-right"}
+          onClick={() =>
+            mapboxClient.camera.zoomTo(
+              [-122.06441040634448, 36.99225113910849],
+              20,
+              true,
+            )
+          }
+        />
+        <Button
+          icon={<ThickArrowUpIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"bottom-left"}
+          className={waypointMode ? "bg-blue-200" : ""}
+          onClick={() => setWaypointMode(!waypointMode)}
+        />
 
-			<div className="overlay-wrapper inset-0 z-10">
-				<Button
-					icon={<SewingPinFilledIcon className="w-5 h-5" />}
-					position={"bottom-right"}
-					onClick={() =>
-						mapboxClient.camera.zoomTo(
-							[-122.06441040634448, 36.99225113910849],
-							20,
-							true,
-						)
-					}
-				/>
-				<Button
-					icon={<ThickArrowUpIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"bottom-left"}
-					className={waypointMode ? "bg-blue-200" : ""}
-					onClick={() => setWaypointMode(!waypointMode)}
-				/>
-
-				{ /* this needs to go */}
-				{selectedWaypoint && (
-					<div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
-						<div className="flex justify-between items-center mb-2">
-							<h3 className="font-semibold">Waypoint Selected</h3>
-							<button
-								className="text-gray-500 hover:text-gray-700"
-								onClick={() => {
-									setSelectedWaypoint(null);
-									mapboxClient.events.removeAnyMarkers();
-								}}
-							>
-								<Cross2Icon className="w-4 h-4" />
-							</button>
-						</div>
-						<p className="text-sm mb-3">
-							Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
-							{selectedWaypoint[0].toFixed(6)}
-						</p>
-						<div className="flex space-x-2">
-							<button
-								onClick={openInGoogleMaps}
-								className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Google Maps
-							</button>
-							<button
-								onClick={openInAppleMaps}
-								className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Apple Maps
-							</button>
+        {/* this needs to go */}
+        {selectedWaypoint && (
+          <div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="font-semibold">Waypoint Selected</h3>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => {
+                  setSelectedWaypoint(null);
+                  mapboxClient.events.removeAnyMarkers();
+                }}
+              >
+                <Cross2Icon className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-sm mb-3">
+              Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
+              {selectedWaypoint[0].toFixed(6)}
+            </p>
+            <div className="flex space-x-2">
+              <button
+                onClick={openInGoogleMaps}
+                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Google Maps
+              </button>
+              <button
+                onClick={openInAppleMaps}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Apple Maps
+              </button>
               <button
                 onClick={createEvent}
                 className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
               >
                 Create Event
               </button>
-						</div>
-					</div>
-				)}
-			</div>
-		</div>
-	);
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default MapView;

--- a/src/views/index.tsx
+++ b/src/views/index.tsx
@@ -1,181 +1,41 @@
-// views/
-import Map from "@/components/Map";
-import { Button } from "@/components/reusable/Button";
-import mapboxClient from "@/services/MapboxClient";
-import {
-  Cross2Icon,
-  PlusCircledIcon,
-  SewingPinFilledIcon,
-  ThickArrowUpIcon,
-} from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
-import { Database } from "@/models/supabase_types";
+// pathfinder/src/views/index.tsx
+import { useState, useEffect, Fragment } from 'react';
+import DesktopView from "./type/desktop";
+import MobileView from "./type/mobile";
+import { type Database } from "@/models/supabase_types";
 
 interface MapViewProps {
-  events: Database["public"]["Tables"]["events_v0"]["Row"][];
+  events_v0: Database['public']['Tables']['events_v0']['Row'][]
 }
 
-const MapView: React.FC<MapViewProps> = ({ events }) => {
-  // modes
-  const [waypointMode, setWaypointMode] = useState(false);
-  const [selectedWaypoint, setSelectedWaypoint] = useState<
-    [number, number] | null
-  >(null);
+const MapView = ({ events_v0 }: MapViewProps) => {
+  const [windowSize, setWindowSize] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {
-    if (!events || events.length === 0) return;
+    const updateSize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      });
+    };
 
-    for (const row of events) {
-      if (
-        row &&
-        typeof row.longitude === "number" &&
-        typeof row.latitude === "number"
-      ) {
-        mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
-      }
-    }
-  }, [events]);
+    updateSize();
 
-  useEffect(() => {
-    if (waypointMode) {
-      document.body.style.cursor = "crosshair";
-      const handleClick = (e: mapboxgl.MapMouseEvent) => {
-        const coordinates = e.lngLat.toArray() as [number, number];
-        setSelectedWaypoint(coordinates);
+    window.addEventListener('resize', updateSize);
 
-        mapboxClient.camera.zoomTo(coordinates, 18, true);
-        mapboxClient.events.addBaseMarker(coordinates);
-        setWaypointMode(false);
-      };
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
 
-      mapboxClient.getMap().once("click", handleClick);
-
-      return () => {
-        document.body.style.cursor = "";
-        mapboxClient.getMap().off("click", handleClick);
-      };
-    } else {
-      document.body.style.cursor = "";
-    }
-  }, [waypointMode]);
-
-  const openInGoogleMaps = () => {
-    if (selectedWaypoint) {
-      const [lng, lat] = selectedWaypoint;
-      window.open(
-        `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
-        "_blank",
-      );
-    }
-  };
-
-  const openInAppleMaps = () => {
-    if (selectedWaypoint) {
-      const [lng, lat] = selectedWaypoint;
-      window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
-    }
-  };
-
-  const createEvent = () => {
-    // perform api call here, will just print to cosnole for now
-    // const supabase = createClient();
-    console.log("* Attempted to create event");
-  };
+  const isDesktop = windowSize && windowSize.width >= 768;
 
   return (
-    <div>
-      <div className="absolute inset-0">
-        <Map />
-      </div>
-
-      <div className="overlay-wrapper inset-0 z-10">
-        <Button
-          icon={<SewingPinFilledIcon className="w-5 h-5" />}
-          position={"bottom-right"}
-          onClick={() =>
-            mapboxClient.camera.zoomTo(
-              [-122.06441040634448, 36.99225113910849],
-              20,
-              true,
-            )
-          }
-        />
-        <Button
-          icon={<ThickArrowUpIcon className="w-5 h-5" />}
-          position={"top-right"}
-          onClick={() => {
-            mapboxClient.geolocation.getUserLocation((coords) => {
-              mapboxClient.camera.zoomTo(
-                [coords.longitude, coords.latitude],
-                20,
-                false,
-              );
-            });
-          }}
-        />
-        <Button
-          icon={<PlusCircledIcon className="w-5 h-5" />}
-          position={"top-right"}
-          onClick={() => {
-            mapboxClient.geolocation.getUserLocation((coords) => {
-              mapboxClient.camera.zoomTo(
-                [coords.longitude, coords.latitude],
-                20,
-                false,
-              );
-            });
-          }}
-        />
-        <Button
-          icon={<PlusCircledIcon className="w-5 h-5" />}
-          position={"bottom-left"}
-          className={waypointMode ? "bg-blue-200" : ""}
-          onClick={() => setWaypointMode(!waypointMode)}
-        />
-
-        {/* this needs to go */}
-        {selectedWaypoint && (
-          <div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
-            <div className="flex justify-between items-center mb-2">
-              <h3 className="font-semibold">Waypoint Selected</h3>
-              <button
-                className="text-gray-500 hover:text-gray-700"
-                onClick={() => {
-                  setSelectedWaypoint(null);
-                  mapboxClient.events.removeAnyMarkers();
-                }}
-              >
-                <Cross2Icon className="w-4 h-4" />
-              </button>
-            </div>
-            <p className="text-sm mb-3">
-              Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
-              {selectedWaypoint[0].toFixed(6)}
-            </p>
-            <div className="flex space-x-2">
-              <button
-                onClick={openInGoogleMaps}
-                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
-              >
-                Google Maps
-              </button>
-              <button
-                onClick={openInAppleMaps}
-                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
-              >
-                Apple Maps
-              </button>
-              <button
-                onClick={createEvent}
-                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
-              >
-                Create Event
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
+    <Fragment>
+      {isDesktop ? (
+        <DesktopView events={events_v0} />
+      ) : (
+        <MobileView events={events_v0}/>
+      )}
+    </Fragment>
   );
 };
 

--- a/src/views/type/desktop.tsx
+++ b/src/views/type/desktop.tsx
@@ -2,183 +2,185 @@
 import Map from "@/components/Map";
 import { Button } from "@/components/reusable/Button";
 import mapboxClient from "@/services/MapboxClient";
-import createClient from '@/supabase/api';
 import {
-	Cross2Icon,
-	PlusCircledIcon,
-	SewingPinFilledIcon,
-	ThickArrowUpIcon,
+  Cross2Icon,
+  PlusCircledIcon,
+  SewingPinFilledIcon,
+  ThickArrowUpIcon,
   PersonIcon,
 } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
 import { Database } from "@/models/supabase_types";
 
 interface MapViewProps {
-  events: Database['public']['Tables']['events_v0']['Row'][];
+  events: Database["public"]["Tables"]["events_v0"]["Row"][];
 }
 
 const DesktopView: React.FC<MapViewProps> = ({ events }) => {
-	// modes
-	const [waypointMode, setWaypointMode] = useState(false);
-	const [selectedWaypoint, setSelectedWaypoint] = useState<
-		[number, number] | null
-	>(null);
+  // modes
+  const [waypointMode, setWaypointMode] = useState(false);
+  const [selectedWaypoint, setSelectedWaypoint] = useState<
+    [number, number] | null
+  >(null);
   const [showAuthTest, setShowAuthTest] = useState(false);
 
-	useEffect(() => {
-     if (!events || events.length === 0) return;
+  useEffect(() => {
+    if (!events || events.length === 0) return;
 
-     for (const row of events) {
-       if (row && typeof row.longitude === 'number' && typeof row.latitude === 'number') {
-         mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
-       }
-     }
-   }, [events]);
+    for (const row of events) {
+      if (
+        row &&
+        typeof row.longitude === "number" &&
+        typeof row.latitude === "number"
+      ) {
+        mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
+      }
+    }
+  }, [events]);
 
-	useEffect(() => {
-		if (waypointMode) {
-			document.body.style.cursor = "crosshair";
-			const handleClick = (e: mapboxgl.MapMouseEvent) => {
-				const coordinates = e.lngLat.toArray() as [number, number];
-				setSelectedWaypoint(coordinates);
+  useEffect(() => {
+    if (waypointMode) {
+      document.body.style.cursor = "crosshair";
+      const handleClick = (e: mapboxgl.MapMouseEvent) => {
+        const coordinates = e.lngLat.toArray() as [number, number];
+        setSelectedWaypoint(coordinates);
 
-				mapboxClient.camera.zoomTo(coordinates, 18, true);
-				mapboxClient.events.addBaseMarker(coordinates);
-				setWaypointMode(false);
-			};
+        mapboxClient.camera.zoomTo(coordinates, 18, true);
+        mapboxClient.events.addBaseMarker(coordinates);
+        setWaypointMode(false);
+      };
 
-			mapboxClient.getMap().once("click", handleClick);
+      mapboxClient.getMap().once("click", handleClick);
 
-			return () => {
-				document.body.style.cursor = "";
-				mapboxClient.getMap().off("click", handleClick);
-			};
-		} else {
-			document.body.style.cursor = "";
-		}
-	}, [waypointMode]);
+      return () => {
+        document.body.style.cursor = "";
+        mapboxClient.getMap().off("click", handleClick);
+      };
+    } else {
+      document.body.style.cursor = "";
+    }
+  }, [waypointMode]);
 
+  const openInGoogleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+        "_blank",
+      );
+    }
+  };
 
-	const openInGoogleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(
-				`https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
-				"_blank",
-			);
-		}
-	};
+  const openInAppleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
+    }
+  };
 
-	const openInAppleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
-		}
-	};
+  const createEvent = () => {
+    // perform api call here, will just print to cosnole for now
+    // const supabase = createClient();
+    console.log("* Attempted to create event");
+  };
 
-	const createEvent = () => {
-	  // perform api call here, will just print to cosnole for now
-		// const supabase = createClient();
-    	console.log("* Attempted to create event");
-	}
+  return (
+    <div>
+      <div className="absolute inset-0">
+        <Map />
+      </div>
 
-	return (
-		<div>
-			<div className="absolute inset-0">
-				<Map />
-			</div>
-
-			<div className="overlay-wrapper inset-0 z-10">
-				<Button
-					icon={<SewingPinFilledIcon className="w-5 h-5" />}
-					position={"bottom-right"}
-					onClick={() =>
-						mapboxClient.camera.zoomTo(
-							[-122.06441040634448, 36.99225113910849],
-							20,
-							true,
-						)
-					}
-				/>
-				<Button
-					icon={<ThickArrowUpIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"bottom-left"}
-					className={waypointMode ? "bg-blue-200" : ""}
-					onClick={() => setWaypointMode(!waypointMode)}
-				/>
+      <div className="overlay-wrapper inset-0 z-10">
+        <Button
+          icon={<SewingPinFilledIcon className="w-5 h-5" />}
+          position={"bottom-right"}
+          onClick={() =>
+            mapboxClient.camera.zoomTo(
+              [-122.06441040634448, 36.99225113910849],
+              20,
+              true,
+            )
+          }
+        />
+        <Button
+          icon={<ThickArrowUpIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"bottom-left"}
+          className={waypointMode ? "bg-blue-200" : ""}
+          onClick={() => setWaypointMode(!waypointMode)}
+        />
         <Button
           icon={<PersonIcon className="w-5 h-5" />}
           position={"top-left"}
           onClick={() => setShowAuthTest(!showAuthTest)}
         />
 
-				{ /* this needs to go */}
-				{selectedWaypoint && (
-					<div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
-						<div className="flex justify-between items-center mb-2">
-							<h3 className="font-semibold">Waypoint Selected</h3>
-							<button
-								className="text-gray-500 hover:text-gray-700"
-								onClick={() => {
-									setSelectedWaypoint(null);
-									mapboxClient.events.removeAnyMarkers();
-								}}
-							>
-								<Cross2Icon className="w-4 h-4" />
-							</button>
-						</div>
-						<p className="text-sm mb-3">
-							Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
-							{selectedWaypoint[0].toFixed(6)}
-						</p>
-						<div className="flex space-x-2">
-							<button
-								onClick={openInGoogleMaps}
-								className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Google Maps
-							</button>
-							<button
-								onClick={openInAppleMaps}
-								className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Apple Maps
-							</button>
+        {/* this needs to go */}
+        {selectedWaypoint && (
+          <div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="font-semibold">Waypoint Selected</h3>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => {
+                  setSelectedWaypoint(null);
+                  mapboxClient.events.removeAnyMarkers();
+                }}
+              >
+                <Cross2Icon className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-sm mb-3">
+              Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
+              {selectedWaypoint[0].toFixed(6)}
+            </p>
+            <div className="flex space-x-2">
+              <button
+                onClick={openInGoogleMaps}
+                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Google Maps
+              </button>
+              <button
+                onClick={openInAppleMaps}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Apple Maps
+              </button>
               <button
                 onClick={createEvent}
                 className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
               >
                 Create Event
               </button>
-						</div>
-					</div>
-				)}
+            </div>
+          </div>
+        )}
 
         {/* Auth Test Overlay */}
         {showAuthTest && (
@@ -194,9 +196,9 @@ const DesktopView: React.FC<MapViewProps> = ({ events }) => {
             </div>
           </div>
         )}
-			</div>
-		</div>
-	);
+      </div>
+    </div>
+  );
 };
 
 export default DesktopView;

--- a/src/views/type/desktop.tsx
+++ b/src/views/type/desktop.tsx
@@ -1,0 +1,202 @@
+// views/type/desktop.tsx
+import Map from "@/components/Map";
+import { Button } from "@/components/reusable/Button";
+import mapboxClient from "@/services/MapboxClient";
+import createClient from '@/supabase/api';
+import {
+	Cross2Icon,
+	PlusCircledIcon,
+	SewingPinFilledIcon,
+	ThickArrowUpIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
+import { useEffect, useState } from "react";
+import { Database } from "@/models/supabase_types";
+
+interface MapViewProps {
+  events: Database['public']['Tables']['events_v0']['Row'][];
+}
+
+const DesktopView: React.FC<MapViewProps> = ({ events }) => {
+	// modes
+	const [waypointMode, setWaypointMode] = useState(false);
+	const [selectedWaypoint, setSelectedWaypoint] = useState<
+		[number, number] | null
+	>(null);
+  const [showAuthTest, setShowAuthTest] = useState(false);
+
+	useEffect(() => {
+     if (!events || events.length === 0) return;
+
+     for (const row of events) {
+       if (row && typeof row.longitude === 'number' && typeof row.latitude === 'number') {
+         mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
+       }
+     }
+   }, [events]);
+
+	useEffect(() => {
+		if (waypointMode) {
+			document.body.style.cursor = "crosshair";
+			const handleClick = (e: mapboxgl.MapMouseEvent) => {
+				const coordinates = e.lngLat.toArray() as [number, number];
+				setSelectedWaypoint(coordinates);
+
+				mapboxClient.camera.zoomTo(coordinates, 18, true);
+				mapboxClient.events.addBaseMarker(coordinates);
+				setWaypointMode(false);
+			};
+
+			mapboxClient.getMap().once("click", handleClick);
+
+			return () => {
+				document.body.style.cursor = "";
+				mapboxClient.getMap().off("click", handleClick);
+			};
+		} else {
+			document.body.style.cursor = "";
+		}
+	}, [waypointMode]);
+
+
+	const openInGoogleMaps = () => {
+		if (selectedWaypoint) {
+			const [lng, lat] = selectedWaypoint;
+			window.open(
+				`https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+				"_blank",
+			);
+		}
+	};
+
+	const openInAppleMaps = () => {
+		if (selectedWaypoint) {
+			const [lng, lat] = selectedWaypoint;
+			window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
+		}
+	};
+
+	const createEvent = () => {
+	  // perform api call here, will just print to cosnole for now
+		// const supabase = createClient();
+    	console.log("* Attempted to create event");
+	}
+
+	return (
+		<div>
+			<div className="absolute inset-0">
+				<Map />
+			</div>
+
+			<div className="overlay-wrapper inset-0 z-10">
+				<Button
+					icon={<SewingPinFilledIcon className="w-5 h-5" />}
+					position={"bottom-right"}
+					onClick={() =>
+						mapboxClient.camera.zoomTo(
+							[-122.06441040634448, 36.99225113910849],
+							20,
+							true,
+						)
+					}
+				/>
+				<Button
+					icon={<ThickArrowUpIcon className="w-5 h-5" />}
+					position={"top-right"}
+					onClick={() => {
+						mapboxClient.geolocation.getUserLocation((coords) => {
+							mapboxClient.camera.zoomTo(
+								[coords.longitude, coords.latitude],
+								20,
+								false,
+							);
+						});
+					}}
+				/>
+				<Button
+					icon={<PlusCircledIcon className="w-5 h-5" />}
+					position={"top-right"}
+					onClick={() => {
+						mapboxClient.geolocation.getUserLocation((coords) => {
+							mapboxClient.camera.zoomTo(
+								[coords.longitude, coords.latitude],
+								20,
+								false,
+							);
+						});
+					}}
+				/>
+				<Button
+					icon={<PlusCircledIcon className="w-5 h-5" />}
+					position={"bottom-left"}
+					className={waypointMode ? "bg-blue-200" : ""}
+					onClick={() => setWaypointMode(!waypointMode)}
+				/>
+        <Button
+          icon={<PersonIcon className="w-5 h-5" />}
+          position={"top-left"}
+          onClick={() => setShowAuthTest(!showAuthTest)}
+        />
+
+				{ /* this needs to go */}
+				{selectedWaypoint && (
+					<div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
+						<div className="flex justify-between items-center mb-2">
+							<h3 className="font-semibold">Waypoint Selected</h3>
+							<button
+								className="text-gray-500 hover:text-gray-700"
+								onClick={() => {
+									setSelectedWaypoint(null);
+									mapboxClient.events.removeAnyMarkers();
+								}}
+							>
+								<Cross2Icon className="w-4 h-4" />
+							</button>
+						</div>
+						<p className="text-sm mb-3">
+							Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
+							{selectedWaypoint[0].toFixed(6)}
+						</p>
+						<div className="flex space-x-2">
+							<button
+								onClick={openInGoogleMaps}
+								className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+							>
+								Google Maps
+							</button>
+							<button
+								onClick={openInAppleMaps}
+								className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+							>
+								Apple Maps
+							</button>
+              <button
+                onClick={createEvent}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Create Event
+              </button>
+						</div>
+					</div>
+				)}
+
+        {/* Auth Test Overlay */}
+        {showAuthTest && (
+          <div className="absolute top-20 left-4 bg-white p-4 rounded-lg shadow-lg max-w-md">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="font-semibold">Authentication Test</h3>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => setShowAuthTest(false)}
+              >
+                <Cross2Icon className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+			</div>
+		</div>
+	);
+};
+
+export default DesktopView;

--- a/src/views/type/mobile.tsx
+++ b/src/views/type/mobile.tsx
@@ -2,183 +2,185 @@
 import Map from "@/components/Map";
 import { Button } from "@/components/reusable/Button";
 import mapboxClient from "@/services/MapboxClient";
-import createClient from '@/supabase/api';
 import {
-	Cross2Icon,
-	PlusCircledIcon,
-	SewingPinFilledIcon,
-	ThickArrowUpIcon,
+  Cross2Icon,
+  PlusCircledIcon,
+  SewingPinFilledIcon,
+  ThickArrowUpIcon,
   PersonIcon,
 } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
 import { Database } from "@/models/supabase_types";
 
 interface MapViewProps {
-  events: Database['public']['Tables']['events_v0']['Row'][];
+  events: Database["public"]["Tables"]["events_v0"]["Row"][];
 }
 
 const MobileView: React.FC<MapViewProps> = ({ events }) => {
-	// modes
-	const [waypointMode, setWaypointMode] = useState(false);
-	const [selectedWaypoint, setSelectedWaypoint] = useState<
-		[number, number] | null
-	>(null);
+  // modes
+  const [waypointMode, setWaypointMode] = useState(false);
+  const [selectedWaypoint, setSelectedWaypoint] = useState<
+    [number, number] | null
+  >(null);
   const [showAuthTest, setShowAuthTest] = useState(false);
 
-	useEffect(() => {
-     if (!events || events.length === 0) return;
+  useEffect(() => {
+    if (!events || events.length === 0) return;
 
-     for (const row of events) {
-       if (row && typeof row.longitude === 'number' && typeof row.latitude === 'number') {
-         mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
-       }
-     }
-   }, [events]);
+    for (const row of events) {
+      if (
+        row &&
+        typeof row.longitude === "number" &&
+        typeof row.latitude === "number"
+      ) {
+        mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
+      }
+    }
+  }, [events]);
 
-	useEffect(() => {
-		if (waypointMode) {
-			document.body.style.cursor = "crosshair";
-			const handleClick = (e: mapboxgl.MapMouseEvent) => {
-				const coordinates = e.lngLat.toArray() as [number, number];
-				setSelectedWaypoint(coordinates);
+  useEffect(() => {
+    if (waypointMode) {
+      document.body.style.cursor = "crosshair";
+      const handleClick = (e: mapboxgl.MapMouseEvent) => {
+        const coordinates = e.lngLat.toArray() as [number, number];
+        setSelectedWaypoint(coordinates);
 
-				mapboxClient.camera.zoomTo(coordinates, 18, true);
-				mapboxClient.events.addBaseMarker(coordinates);
-				setWaypointMode(false);
-			};
+        mapboxClient.camera.zoomTo(coordinates, 18, true);
+        mapboxClient.events.addBaseMarker(coordinates);
+        setWaypointMode(false);
+      };
 
-			mapboxClient.getMap().once("click", handleClick);
+      mapboxClient.getMap().once("click", handleClick);
 
-			return () => {
-				document.body.style.cursor = "";
-				mapboxClient.getMap().off("click", handleClick);
-			};
-		} else {
-			document.body.style.cursor = "";
-		}
-	}, [waypointMode]);
+      return () => {
+        document.body.style.cursor = "";
+        mapboxClient.getMap().off("click", handleClick);
+      };
+    } else {
+      document.body.style.cursor = "";
+    }
+  }, [waypointMode]);
 
+  const openInGoogleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(
+        `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+        "_blank",
+      );
+    }
+  };
 
-	const openInGoogleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(
-				`https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
-				"_blank",
-			);
-		}
-	};
+  const openInAppleMaps = () => {
+    if (selectedWaypoint) {
+      const [lng, lat] = selectedWaypoint;
+      window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
+    }
+  };
 
-	const openInAppleMaps = () => {
-		if (selectedWaypoint) {
-			const [lng, lat] = selectedWaypoint;
-			window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
-		}
-	};
+  const createEvent = () => {
+    // perform api call here, will just print to cosnole for now
+    // const supabase = createClient();
+    console.log("* Attempted to create event");
+  };
 
-	const createEvent = () => {
-	  // perform api call here, will just print to cosnole for now
-		// const supabase = createClient();
-    	console.log("* Attempted to create event");
-	}
+  return (
+    <div>
+      <div className="absolute inset-0">
+        <Map />
+      </div>
 
-	return (
-		<div>
-			<div className="absolute inset-0">
-				<Map />
-			</div>
-
-			<div className="overlay-wrapper inset-0 z-10">
-				<Button
-					icon={<SewingPinFilledIcon className="w-5 h-5" />}
-					position={"bottom-right"}
-					onClick={() =>
-						mapboxClient.camera.zoomTo(
-							[-122.06441040634448, 36.99225113910849],
-							20,
-							true,
-						)
-					}
-				/>
-				<Button
-					icon={<ThickArrowUpIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"top-right"}
-					onClick={() => {
-						mapboxClient.geolocation.getUserLocation((coords) => {
-							mapboxClient.camera.zoomTo(
-								[coords.longitude, coords.latitude],
-								20,
-								false,
-							);
-						});
-					}}
-				/>
-				<Button
-					icon={<PlusCircledIcon className="w-5 h-5" />}
-					position={"bottom-left"}
-					className={waypointMode ? "bg-blue-200" : ""}
-					onClick={() => setWaypointMode(!waypointMode)}
-				/>
+      <div className="overlay-wrapper inset-0 z-10">
+        <Button
+          icon={<SewingPinFilledIcon className="w-5 h-5" />}
+          position={"bottom-right"}
+          onClick={() =>
+            mapboxClient.camera.zoomTo(
+              [-122.06441040634448, 36.99225113910849],
+              20,
+              true,
+            )
+          }
+        />
+        <Button
+          icon={<ThickArrowUpIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"top-right"}
+          onClick={() => {
+            mapboxClient.geolocation.getUserLocation((coords) => {
+              mapboxClient.camera.zoomTo(
+                [coords.longitude, coords.latitude],
+                20,
+                false,
+              );
+            });
+          }}
+        />
+        <Button
+          icon={<PlusCircledIcon className="w-5 h-5" />}
+          position={"bottom-left"}
+          className={waypointMode ? "bg-blue-200" : ""}
+          onClick={() => setWaypointMode(!waypointMode)}
+        />
         <Button
           icon={<PersonIcon className="w-5 h-5" />}
           position={"top-left"}
           onClick={() => setShowAuthTest(!showAuthTest)}
         />
 
-				{ /* this needs to go */}
-				{selectedWaypoint && (
-					<div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
-						<div className="flex justify-between items-center mb-2">
-							<h3 className="font-semibold">Waypoint Selected</h3>
-							<button
-								className="text-gray-500 hover:text-gray-700"
-								onClick={() => {
-									setSelectedWaypoint(null);
-									mapboxClient.events.removeAnyMarkers();
-								}}
-							>
-								<Cross2Icon className="w-4 h-4" />
-							</button>
-						</div>
-						<p className="text-sm mb-3">
-							Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
-							{selectedWaypoint[0].toFixed(6)}
-						</p>
-						<div className="flex space-x-2">
-							<button
-								onClick={openInGoogleMaps}
-								className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Google Maps
-							</button>
-							<button
-								onClick={openInAppleMaps}
-								className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
-							>
-								Apple Maps
-							</button>
+        {/* this needs to go */}
+        {selectedWaypoint && (
+          <div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="font-semibold">Waypoint Selected</h3>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => {
+                  setSelectedWaypoint(null);
+                  mapboxClient.events.removeAnyMarkers();
+                }}
+              >
+                <Cross2Icon className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-sm mb-3">
+              Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
+              {selectedWaypoint[0].toFixed(6)}
+            </p>
+            <div className="flex space-x-2">
+              <button
+                onClick={openInGoogleMaps}
+                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Google Maps
+              </button>
+              <button
+                onClick={openInAppleMaps}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Apple Maps
+              </button>
               <button
                 onClick={createEvent}
                 className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
               >
                 Create Event
               </button>
-						</div>
-					</div>
-				)}
+            </div>
+          </div>
+        )}
 
         {/* Auth Test Overlay */}
         {showAuthTest && (
@@ -194,9 +196,9 @@ const MobileView: React.FC<MapViewProps> = ({ events }) => {
             </div>
           </div>
         )}
-			</div>
-		</div>
-	);
+      </div>
+    </div>
+  );
 };
 
 export default MobileView;

--- a/src/views/type/mobile.tsx
+++ b/src/views/type/mobile.tsx
@@ -1,0 +1,202 @@
+// views/type/mobile.tsx
+import Map from "@/components/Map";
+import { Button } from "@/components/reusable/Button";
+import mapboxClient from "@/services/MapboxClient";
+import createClient from '@/supabase/api';
+import {
+	Cross2Icon,
+	PlusCircledIcon,
+	SewingPinFilledIcon,
+	ThickArrowUpIcon,
+  PersonIcon,
+} from "@radix-ui/react-icons";
+import { useEffect, useState } from "react";
+import { Database } from "@/models/supabase_types";
+
+interface MapViewProps {
+  events: Database['public']['Tables']['events_v0']['Row'][];
+}
+
+const MobileView: React.FC<MapViewProps> = ({ events }) => {
+	// modes
+	const [waypointMode, setWaypointMode] = useState(false);
+	const [selectedWaypoint, setSelectedWaypoint] = useState<
+		[number, number] | null
+	>(null);
+  const [showAuthTest, setShowAuthTest] = useState(false);
+
+	useEffect(() => {
+     if (!events || events.length === 0) return;
+
+     for (const row of events) {
+       if (row && typeof row.longitude === 'number' && typeof row.latitude === 'number') {
+         mapboxClient.events.addEventMarker([row.longitude, row.latitude]);
+       }
+     }
+   }, [events]);
+
+	useEffect(() => {
+		if (waypointMode) {
+			document.body.style.cursor = "crosshair";
+			const handleClick = (e: mapboxgl.MapMouseEvent) => {
+				const coordinates = e.lngLat.toArray() as [number, number];
+				setSelectedWaypoint(coordinates);
+
+				mapboxClient.camera.zoomTo(coordinates, 18, true);
+				mapboxClient.events.addBaseMarker(coordinates);
+				setWaypointMode(false);
+			};
+
+			mapboxClient.getMap().once("click", handleClick);
+
+			return () => {
+				document.body.style.cursor = "";
+				mapboxClient.getMap().off("click", handleClick);
+			};
+		} else {
+			document.body.style.cursor = "";
+		}
+	}, [waypointMode]);
+
+
+	const openInGoogleMaps = () => {
+		if (selectedWaypoint) {
+			const [lng, lat] = selectedWaypoint;
+			window.open(
+				`https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+				"_blank",
+			);
+		}
+	};
+
+	const openInAppleMaps = () => {
+		if (selectedWaypoint) {
+			const [lng, lat] = selectedWaypoint;
+			window.open(`https://maps.apple.com/?q=${lat},${lng}`, "_blank");
+		}
+	};
+
+	const createEvent = () => {
+	  // perform api call here, will just print to cosnole for now
+		// const supabase = createClient();
+    	console.log("* Attempted to create event");
+	}
+
+	return (
+		<div>
+			<div className="absolute inset-0">
+				<Map />
+			</div>
+
+			<div className="overlay-wrapper inset-0 z-10">
+				<Button
+					icon={<SewingPinFilledIcon className="w-5 h-5" />}
+					position={"bottom-right"}
+					onClick={() =>
+						mapboxClient.camera.zoomTo(
+							[-122.06441040634448, 36.99225113910849],
+							20,
+							true,
+						)
+					}
+				/>
+				<Button
+					icon={<ThickArrowUpIcon className="w-5 h-5" />}
+					position={"top-right"}
+					onClick={() => {
+						mapboxClient.geolocation.getUserLocation((coords) => {
+							mapboxClient.camera.zoomTo(
+								[coords.longitude, coords.latitude],
+								20,
+								false,
+							);
+						});
+					}}
+				/>
+				<Button
+					icon={<PlusCircledIcon className="w-5 h-5" />}
+					position={"top-right"}
+					onClick={() => {
+						mapboxClient.geolocation.getUserLocation((coords) => {
+							mapboxClient.camera.zoomTo(
+								[coords.longitude, coords.latitude],
+								20,
+								false,
+							);
+						});
+					}}
+				/>
+				<Button
+					icon={<PlusCircledIcon className="w-5 h-5" />}
+					position={"bottom-left"}
+					className={waypointMode ? "bg-blue-200" : ""}
+					onClick={() => setWaypointMode(!waypointMode)}
+				/>
+        <Button
+          icon={<PersonIcon className="w-5 h-5" />}
+          position={"top-left"}
+          onClick={() => setShowAuthTest(!showAuthTest)}
+        />
+
+				{ /* this needs to go */}
+				{selectedWaypoint && (
+					<div className="absolute bottom-20 left-4 bg-white p-4 rounded-lg shadow-lg">
+						<div className="flex justify-between items-center mb-2">
+							<h3 className="font-semibold">Waypoint Selected</h3>
+							<button
+								className="text-gray-500 hover:text-gray-700"
+								onClick={() => {
+									setSelectedWaypoint(null);
+									mapboxClient.events.removeAnyMarkers();
+								}}
+							>
+								<Cross2Icon className="w-4 h-4" />
+							</button>
+						</div>
+						<p className="text-sm mb-3">
+							Coordinates: {selectedWaypoint[1].toFixed(6)},{" "}
+							{selectedWaypoint[0].toFixed(6)}
+						</p>
+						<div className="flex space-x-2">
+							<button
+								onClick={openInGoogleMaps}
+								className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm"
+							>
+								Google Maps
+							</button>
+							<button
+								onClick={openInAppleMaps}
+								className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+							>
+								Apple Maps
+							</button>
+              <button
+                onClick={createEvent}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-3 py-1 rounded text-sm"
+              >
+                Create Event
+              </button>
+						</div>
+					</div>
+				)}
+
+        {/* Auth Test Overlay */}
+        {showAuthTest && (
+          <div className="absolute top-20 left-4 bg-white p-4 rounded-lg shadow-lg max-w-md">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="font-semibold">Authentication Test</h3>
+              <button
+                className="text-gray-500 hover:text-gray-700"
+                onClick={() => setShowAuthTest(false)}
+              >
+                <Cross2Icon className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+			</div>
+		</div>
+	);
+};
+
+export default MobileView;


### PR DESCRIPTION
## refactor view to accommodate both mobile and desktop
Split in `views/type/desktop.tsx` and `views/type/mobile.tsx`.

Props are passed down but should be maintained through state in next focused path.

https://linear.app/pvthfinder/issue/PAT-31/refactoring-view-to-be-split-between-desktop-mobile