### PR TITLE
Download orgs on load

### DIFF
--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -5,6 +5,8 @@
  */
 
 /* */
+import type { Database } from '@/models/supabase_types'
+
 export type ButtonLayoutPosition =
 	| "top-left"
 	| "top-right"
@@ -43,3 +45,6 @@ interface GeoJSON {
 	type: "FeatureCollection";
 	features: Feature[];
 }
+
+export type EventRow = Database['authenticated']['Views']['events']['Row']
+export type OrgRow = Pick<Database['authenticated']['Tables']['organizations_v0']['Row'], 'id' | 'name'>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,27 +1,49 @@
-import Head from "next/head";
 import { NextPage } from "next";
 import type { GetServerSidePropsContext } from "next";
 import { createClient } from "@/supabase/server-props";
-import { type Database } from "@/models/supabase_types";
 import MapView from "@/views";
+import type {EventRow, OrgRow } from "@/models/types"
 
 const Homepage: NextPage<{
-  events: Database["authenticated"]["Views"]["events"]["Row"][];
-}> = ({ events }) => {
+  events: EventRow[], orgs: OrgRow[];
+}> = ({ events, orgs }) => {
   return (
     <div>
       {/* Main view will go here */}
-      <MapView events={events} />
+      <MapView events={events} orgs={orgs} />
     </div>
   );
 };
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const supabase = createClient(context);
-  const { data: events , error} = await supabase.from("events").select();
+
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    console.error("User not found or error:", userError);
+    return {
+      props: {
+        events: [],
+        orgs: []
+      }
+    }
+  }
+
+  const { data: events , error: error_events} = await supabase.from("events").select();
+  if (error_events) throw error_events;
+
+  const { data: orgs, error: error_orgs } = await supabase
+    .from('user_organizations_v0')
+    .select(
+      '...organizations_v0(id,name)',
+    )
+    .eq('user_id', user?.id);
+  if (error_orgs) throw error_orgs;
+  console.log(orgs)
   return {
     props: {
       events: events,
+      orgs: orgs
     },
   };
 }

--- a/src/stores/useOrgsStore.ts
+++ b/src/stores/useOrgsStore.ts
@@ -1,33 +1,33 @@
-// stores/useEventsStore
+// stores/useOrgsStore
 import { create } from "zustand";
-import { EventRow } from "@/models/types"
+import type { OrgRow } from "@/models/types"; 
 
-export interface EventsState {
-  events: EventRow[];
+export interface OrgsState {
+  orgs: OrgRow[];
   loading: boolean;
   error: string | null;
 }
 
-export interface EventsActions {
-  setEvents: (events: EventRow[]) => void;
+export interface OrgsActions {
+  setOrgs: (orgs: OrgRow[]) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
-  // add an action to fetch events if they weren't from SSR, e.g.:
-  // fetchEvents: () => Promise<void>;
+  // add an action to fetch orgs if they weren't from SSR, e.g.:
+  // fetchOrgs: () => Promise<void>;
 }
 
-export type EventsStore = EventsState & EventsActions;
+export type OrgsStore = OrgsState & OrgsActions;
 
-export const useEventsStore = create<EventsStore>((set) => ({
+export const useOrgsStore = create<OrgsStore>((set) => ({
   // initial state
-  events: [],
+  orgs: [],
   loading: true,
   error: null,
 
   // possible actions
-  setEvents: (events) => set((state) => ({
+  setOrgs: (orgs) => set((state) => ({
     ...state,
-    events: events,
+    orgs: orgs,
     loading: false,
     error: null
   })),

--- a/src/views/index.tsx
+++ b/src/views/index.tsx
@@ -2,17 +2,21 @@
 import { useState, useEffect } from 'react';
 import DesktopView from "./type/desktop";
 import MobileView from "./type/mobile";
-import { type Database } from "@/models/supabase_types";
+import type {EventRow, OrgRow} from "@/models/types"
 
 import { useEventsStore } from '@/stores/useEventsStore';
+import { useOrgsStore } from '@/stores/useOrgsStore';
+
 
 interface MapViewProps {
-  events: Database['authenticated']['Views']['events']['Row'][]
+  events: EventRow[],
+  orgs: OrgRow[]
 }
 
-const MapView = ({ events }: MapViewProps) => {
+const MapView = ({ events, orgs }: MapViewProps) => {
   const [windowSize, setWindowSize] = useState<{ width: number; height: number } | null>(null);
   const setEvents = useEventsStore(state => state.setEvents);
+  const setOrgs = useOrgsStore(state => state.setOrgs);
 
   useEffect(() => {
     const updateSize = () => {
@@ -36,6 +40,15 @@ const MapView = ({ events }: MapViewProps) => {
       setEvents(events);
     }
   }, [events, setEvents]);
+
+  useEffect(() => {
+    if (!orgs) {
+      console.error("ERROR: No orgs were loaded.");
+    } else {
+      console.log(orgs)
+      setOrgs(orgs);
+    }
+  }, [orgs, setOrgs]);
 
   const isDesktop = windowSize && windowSize.width >= 768;
   const ViewComponent = isDesktop ? DesktopView : MobileView;

--- a/src/views/type/desktop.tsx
+++ b/src/views/type/desktop.tsx
@@ -1,17 +1,8 @@
 // views/type/desktop.tsx
 import Map from "@/components/Map";
-import { Button } from "@/components/reusable/Button";
 import mapboxClient from "@/services/MapboxClient";
 import { EventData } from "@/components/specific/RSVP";
-import {
-  Cross2Icon,
-  PlusCircledIcon,
-  ThickArrowUpIcon,
-  PersonIcon,
-} from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
-import { Database } from "@/models/supabase_types";
-import EmailModalButton from "@/components/specific/EmailModal";
 import { createClient } from "@/supabase/component";
 import DashboardLayout from "@/layouts/DashboardLayout";
 import WaypointPopup from "@/components/specific/WaypointPopup";

--- a/src/views/type/mobile.tsx
+++ b/src/views/type/mobile.tsx
@@ -1,6 +1,5 @@
 // views/type/desktop.tsx
 import DesktopView from "./desktop";
-import { Database } from "@/models/supabase_types";
 
 const MobileView: React.FC = () => {
   return <DesktopView />


### PR DESCRIPTION
On load page, we download all orgs that the user is a part of. Also, if the user is not authenticated, we do not query for events or orgs. Created a store for orgs, removed unused imports, and refactored types so that the returned query type is found in types.ts